### PR TITLE
hail 0.2.127 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,3 +6,6 @@ channels:
     - https://staging.continuum.io/prefect/fs/azure-mgmt-storage-feedstock/pr2/eb9f9ea
     - https://staging.continuum.io/prefect/fs/humanize-feedstock/pr8/23f24f0
     - https://staging.continuum.io/prefect/fs/nest-asyncio-feedstock/pr7/fdde43d
+    - https://staging.continuum.io/prefect/fs/parsimonious-feedstock/pr2/f47c443
+    - https://staging.continuum.io/prefect/fs/jproperties-feedstock/pr2/363084a
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 upload_channels:
   - sfe1ed40
+
+channels:
+    - https://staging.continuum.io/prefect/fs/janus-feedstock/pr2/12afd44
+    - https://staging.continuum.io/prefect/fs/azure-mgmt-storage-feedstock/pr2/eb9f9ea

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,10 +2,5 @@ upload_channels:
   - sfe1ed40
 
 channels:
-    - https://staging.continuum.io/prefect/fs/janus-feedstock/pr2/12afd44
-    - https://staging.continuum.io/prefect/fs/azure-mgmt-storage-feedstock/pr2/eb9f9ea
-    - https://staging.continuum.io/prefect/fs/humanize-feedstock/pr8/23f24f0
-    - https://staging.continuum.io/prefect/fs/nest-asyncio-feedstock/pr7/fdde43d
-    - https://staging.continuum.io/prefect/fs/parsimonious-feedstock/pr2/f47c443
-    - https://staging.continuum.io/prefect/fs/jproperties-feedstock/pr2/363084a
+  - https://staging.continuum.io/prefect/fs/libsimdpp-feedstock/pr1/0604445
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ upload_channels:
   - sfe1ed40
 
 channels:  
-  - https://staging.continuum.io/prefect/fs/libsimdpp-feedstock/pr2/6a58062
+  - https://staging.continuum.io/prefect/fs/catch2-feedstock/pr1/3045717

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:  
-  - https://staging.continuum.io/prefect/fs/catch2-feedstock/pr1/3045717

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libsimdpp-feedstock/pr1/0604445
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,5 @@ upload_channels:
 channels:
     - https://staging.continuum.io/prefect/fs/janus-feedstock/pr2/12afd44
     - https://staging.continuum.io/prefect/fs/azure-mgmt-storage-feedstock/pr2/eb9f9ea
+    - https://staging.continuum.io/prefect/fs/humanize-feedstock/pr8/23f24f0
+    - https://staging.continuum.io/prefect/fs/nest-asyncio-feedstock/pr7/fdde43d

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 upload_channels:
   - sfe1ed40
+
+channels:  
+  - https://staging.continuum.io/prefect/fs/libsimdpp-feedstock/pr2/6a58062

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Build instructions
+# https://hail.is/docs/0.2/getting_started_developing.html#requirements
+pushd $SRC_DIR/hail
+make install HAIL_COMPILE_NATIVES=1 -j ${CPU_COUNT}
+popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,6 @@ requirements:
     - openjdk 11.*
     - lz4
     # blas (lapack is brought in along)
-    - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
     # libsimdpp and catch2 unvendored dependencies
     - libsimdpp
     - catch2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -116,6 +116,22 @@ requirements:
     # because pkg_resources is needed
     - setuptools
 
+# skip tests that require a backend or datafiles
+{% set tests_to_skip = "test_hadoop_ or test_annotate_intervals_ or test_verify_biallelic or test_table_filter_intervals" %}
+{% set tests_to_skip = tests_to_skip + " or test_matrix_filter_intervals or test_filter_intervals_compound_key" %}
+{% set tests_to_skip = tests_to_skip + " or test_export_rectangles or test_sparsify_band_ or test_row_intervals_1 or test_sparsify_row_intervals_0" %}
+{% set tests_to_skip = tests_to_skip + " or test_parses or test_tlocus_schema_from_rg_matches_scala or test_requester_pays_" %}
+{% set tests_to_skip = tests_to_skip + " or test_pedigree or test_slices_with_sparsify or test_exceptions_from_workers_have_stack_traces" %}
+{% set tests_to_skip = tests_to_skip + " or test_hail_in_notebook or test_pgenchisq" %}
+# ignore test files that require a backend or datafiles
+{% set testfiles_to_ignore = "--ignore=test/hail/genetics/test_reference_genome.py --ignore=test/hail/methods/test_king.py --ignore=test/hail/methods/test_simulation.py" %}
+{% set testfiles_to_ignore = testfiles_to_ignore + " --ignore=test/hail/methods/relatedness/test_identity_by_descent.py --ignore=test/hail/methods/test_qc.py --ignore=test/hailtop/" %}
+{% set testfiles_to_ignore = testfiles_to_ignore + " --ignore=test/hail/matrixtable/test_file_formats.py --ignore=test/hail/experimental/test_experimental.py --ignore=test/hail/expr/test_expr.py" %}
+{% set testfiles_to_ignore = testfiles_to_ignore + " --ignore=test/hail/matrixtable/test_matrix_table.py --ignore=test/hail/methods/test_family_methods.py --ignore=test/hail/methods/test_impex.py" %}
+{% set testfiles_to_ignore = testfiles_to_ignore + " --ignore=test/hail/methods/test_pca.py --ignore=test/hail/methods/test_skat.py --ignore=test/hail/methods/test_statgen.py" %}
+{% set testfiles_to_ignore = testfiles_to_ignore + " --ignore=test/hail/methods/relatedness/test_pc_relate.py --ignore=test/hail/table/test_table.py --ignore=test/hail/vds/test_combiner.py" %}
+{% set testfiles_to_ignore = testfiles_to_ignore + " --ignore=test/hail/vds/test_vds.py --ignore=test/hail/utils/test_hl_hadoop_and_hail_fs.py --ignore=test/hail/extract_intervals/" %}
+
 test:
   imports:
     - hail
@@ -128,7 +144,7 @@ test:
   commands:
     - pip check
     - cd hail/python
-    - pytest -v test --ignore=test/hailtop/ --ignore=test/hail/matrixtable/test_file_formats.py --ignore=test/hail/experimental/test_experimental.py --ignore=test/hail/expr/test_expr.py --ignore=test/hail/matrixtable/test_matrix_table.py --ignore=test/hail/methods/test_family_methods.py --ignore=test/hail/methods/test_impex.py --ignore=test/hail/methods/test_pca.py --ignore=test/hail/methods/test_skat.py --ignore=test/hail/methods/test_statgen.py --ignore=test/hail/methods/relatedness/test_pc_relate.py --ignore=test/hail/table/test_table.py --ignore=test/hail/vds/test_combiner.py --ignore=test/hail/vds/test_vds.py --ignore=test/hail/utils/test_hl_hadoop_and_hail_fs.py --ignore=test/hail/extract_intervals/
+    - pytest -v test -k "not ({{ tests_to_skip }})" {{ testfiles_to_ignore }}
 
 about:
   home: https://hail.is

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,12 +74,22 @@ test:
 
 about:
   home: https://hail.is
-  dev_url: https://github.com/hail-is/hail
   license: MIT
   license_file: LICENSE
+  license_family: MIT
   summary: |
     Hail is Python-based data analysis tool for working with genomic data.
+  description: |
+    Hail is an open-source, general-purpose, Python-based data analysis 
+    tool with additional data types and methods for working with genomic data.
 
+    Hail is built to scale and has first-class support for multi-dimensional
+    structured data, like the genomic data in a genome-wide association study (GWAS).
+
+    Hail is exposed as a Python library, using primitives for distributed queries and
+    linear algebra implemented in Scala, Spark, and increasingly C++.
+  dev_url: https://github.com/hail-is/hail
+  doc_url: https://hail.is/docs/0.2/
 extra:
   skip-lints:
     - uses_vcs_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,24 +6,60 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/hail-is/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: def7eb3e17d15bbb3dfba00dfc8a966771b839b04b639386ee61c8927d0c7ae8
+  # the build process requires a repository to set some variables
+  # (e.g. version)
+  git_url: https://github.com/hail-is/hail.git
+  git_rev: {{ version }}
 
 build:
   number: 0
+  # avro and others a not available for win
+  skip: true  # [py<39 or win or py>311]
+  # entry_points:
+  #   - hailctl = hailtop.hailctl.__main__:main
 
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - make
+    - make  # [linux]
     # - rsync
   host:
     - python
     - pip
+    - setuptools
+    - pytest-runner
     - pyspark >=3.3.2,<=3.4.1
     - openjdk 11.*
     - lz4
     - libsimdpp
+    # hailctl build needs these here
+    - aiodns >=2.0.0,<3
+    - aiohttp >=3.9,<4
+    - azure-identity >=1.6.0,<2
+    - azure-mgmt-storage ==20.1.0
+    - azure-storage-blob >=12.11.0,<13
+    - boto3 >=1.17,<2.0
+    - botocore >=1.20,<2.0
+    - dill >=0.3.6,<0.4
+    - frozenlist >=1.3.1,<2
+    - google-auth >=2.14.1,<3
+    - google-auth-oauthlib >=0.5.2,<1
+    - humanize >=1.0.0,<2
+    - janus >=0.6,<1.1
+    - nest-asyncio <2,>=1.5.8
+    - orjson >=3.6.4,<4
+    # - protobuf ==3.20.2
+    # we have protobuf 3.20.3
+    - protobuf >=3.20.2,<=3.20.3
+    # - rich <13,>=12.6.0
+    # we have rich 12.5.0
+    - typer >=0.9.0,<1
+    - python-json-logger >=2.0.2,<3
+    - pyyaml >=6.0,<7.0
+    - sortedcontainers >=2.4.0,<3
+    - tabulate >=0.8.9,<1
+    - uvloop >=0.19.0,<1  # [not win]
+    - jproperties >=2.1.1,<3
   run:
     - python
     - openjdk 11.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
     - patches/0002-remove-vendored-catch2.patch
     - patches/0003-patch-requirements.patch
     - patches/0004-pluggy-old-style-wrappers.patch
+    - patches/0005-patch-spark-3.3.2-to-3.4.1.patch
 
 build:
   number: 0
@@ -127,7 +128,7 @@ test:
   commands:
     - pip check
     - cd hail/python
-    - pytest -v test --ignore=test/hailtop/ --ignore=test/hail/matrixtable/test_file_formats.py --ignore=test/hail/experimental/test_experimental.py --ignore=test/hail/expr/test_expr.py --ignore=test/hail/matrixtable/test_matrix_table.py --ignore=test/hail/methods/test_family_methods.py --ignore=test/hail/methods/test_impex.py --ignore=test/hail/methods/test_pca.py --ignore=test/hail/methods/test_skat.py --ignore=test/hail/methods/test_statgen.py --ignore=test/hail/methods/relatedness/test_pc_relate.py --ignore=test/hail/table/test_table.py --ignore=test/hail/vds/test_combiner.py --ignore=test/hail/vds/test_vds.py 
+    - pytest -v test --ignore=test/hailtop/ --ignore=test/hail/matrixtable/test_file_formats.py --ignore=test/hail/experimental/test_experimental.py --ignore=test/hail/expr/test_expr.py --ignore=test/hail/matrixtable/test_matrix_table.py --ignore=test/hail/methods/test_family_methods.py --ignore=test/hail/methods/test_impex.py --ignore=test/hail/methods/test_pca.py --ignore=test/hail/methods/test_skat.py --ignore=test/hail/methods/test_statgen.py --ignore=test/hail/methods/relatedness/test_pc_relate.py --ignore=test/hail/table/test_table.py --ignore=test/hail/vds/test_combiner.py --ignore=test/hail/vds/test_vds.py --ignore=test/hail/utils/test_hl_hadoop_and_hail_fs.py --ignore=test/hail/extract_intervals/
 
 about:
   home: https://hail.is

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,6 +60,7 @@ requirements:
     - tabulate >=0.8.9,<1
     - uvloop >=0.19.0,<1  # [not win]
     - jproperties >=2.1.1,<3
+    - pkg_resources
   run:
     - python
     - openjdk 11.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - python
     - pip
     - setuptools
+    # pre requisites
     - pytest-runner
     - pyspark >=3.3.2,<=3.4.1
     - openjdk 11.*
@@ -57,13 +58,14 @@ requirements:
     - google-auth-oauthlib >=0.5.2,<1
     - humanize >=1.0.0,<2
     - janus >=0.6,<1.1
-    - nest-asyncio <2,>=1.5.8
+    - nest-asyncio >=1.5.8,<2
     - orjson >=3.6.4,<4
     # - protobuf ==3.20.2
     # we have protobuf 3.20.3
     - protobuf >=3.20.2,<=3.20.3
-    # - rich <13,>=12.6.0
+    # - rich >=12.6.0,<13
     # we have rich 12.5.0
+    - rich >=12.5.0,<13
     - typer >=0.9.0,<1
     - python-json-logger >=2.0.2,<3
     - pyyaml >=6.0,<7.0
@@ -74,45 +76,45 @@ requirements:
   run:
     - python
     - openjdk 11.*
-    - aiodns <3,>=2.0.0
-    - aiohttp <4,>=3.9
-    - azure-identity <2,>=1.6.0
+    - aiodns >=2.0.0,<3
+    - aiohttp >=3.9,<4
+    - azure-identity >=1.6.0,<2
     - azure-mgmt-storage ==20.1.0
-    - azure-storage-blob <13,>=12.11.0
-    - boto3 <2.0,>=1.17
-    - botocore <2.0,>=1.20
-    - dill <0.4,>=0.3.6
-    - frozenlist <2,>=1.3.1
-    - google-auth <3,>=2.14.1
-    - google-auth-oauthlib <1,>=0.5.2
-    - humanize <2,>=1.0.0
-    - janus <1.1,>=0.6
-    - nest-asyncio <2,>=1.5.8
-    - orjson <4,>=3.6.4
+    - azure-storage-blob >=12.11.0,<13
+    - boto3 >=1.17,<2.0
+    - botocore >=1.20,<2.0
+    - dill >=0.3.6,<0.4
+    - frozenlist >=1.3.1,<2
+    - google-auth >=2.14.1,<3
+    - google-auth-oauthlib >=0.5.2,<1
+    - humanize >=1.0.0,<2
+    - janus >=0.6,<1.1
+    - nest-asyncio >=1.5.8,<2
+    - orjson >=3.6.4,<4
     # - protobuf ==3.20.2
     # we have protobuf 3.20.3
     - protobuf >=3.20.2,<=3.20.3
-    # - rich <13,>=12.6.0
+    # - rich >=12.6.0,<13
     # we have rich 12.5.0
-    - rich <13,>=12.5.0
-    - typer <1,>=0.9.0
-    - python-json-logger <3,>=2.0.2
-    - pyyaml <7.0,>=6.0
-    - sortedcontainers <3,>=2.4.0
-    - tabulate <1,>=0.8.9
-    - jproperties <3,>=2.1.1
-    - avro <1.12,>=1.10
-    - bokeh <4,>=3
+    - rich >=12.5.0,<13
+    - typer >=0.9.0,<1
+    - python-json-logger >=2.0.2,<3
+    - pyyaml >=6.0,<7.0
+    - sortedcontainers >=2.4.0,<3
+    - tabulate >=0.8.9,<1
+    - jproperties >=2.1.1,<3
+    - avro >=1.10,<1.12
+    - bokeh >=3,<4
     - decorator <5
-    - Deprecated <1.3,>=1.2.10
+    - Deprecated >=1.2.10,<1.3
     - numpy <2
-    - pandas <3,>=2
+    - pandas >=2,<3
     - parsimonious <1
-    - plotly <6,>=5.18.0
-    - pyspark <=3.4.1,>=3.3.2
-    - requests <3,>=2.31.0
-    - scipy <1.12,>1.2
-    - uvloop <1,>=0.19.0  # [not win]
+    - plotly >=5.18.0,<6
+    - pyspark >=3.3.2,<=3.4.1
+    - requests >=2.31.0,<3
+    - scipy >1.2,<1.12
+    - uvloop >=0.19.0,<1  # [not win]
     # because pkg_resources is needed
     - setuptools
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ build:
   # avro and others a not available for win
   # openjdk and pyspark not available for s390x
   skip: true  # [py<39 or win or py>311 or s390x]
+  skip: true  # [blas_impl == "mkl"]
   entry_points:
     - hailctl = hailtop.hailctl.__main__:main
 
@@ -42,7 +43,6 @@ requirements:
     - openjdk 11.*
     - lz4
     # blas (lapack is brought in along)
-    - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
     - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
     # libsimdpp and catch2 unvendored dependencies
     - libsimdpp
@@ -81,7 +81,6 @@ requirements:
     # prerequisites
     - openjdk 11.*
     # blas (lapack is brought in along)
-    - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
     - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
     # deps
     - aiodns >=2.0.0,<3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,83 @@
+{% set name = 'hail' %}
+{% set version = '0.2.127' %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/hail-is/hail.git
+  git_rev: {{ version }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - make
+    # - rsync
+  host:
+    - python
+    - pip
+    - pyspark >=3.3.2,<=3.4.1
+    - openjdk 11.*
+    - lz4
+    - libsimdpp
+  run:
+    - python
+    - openjdk 11.*
+    - aiodns <3,>=2.0.0
+    - aiohttp <4,>=3.9
+    - azure-identity <2,>=1.6.0
+    - azure-mgmt-storage ==20.1.0
+    - azure-storage-blob <13,>=12.11.0
+    - boto3 <2.0,>=1.17
+    - botocore <2.0,>=1.20
+    - dill <0.4,>=0.3.6
+    - frozenlist <2,>=1.3.1
+    - google-auth <3,>=2.14.1
+    - google-auth-oauthlib <1,>=0.5.2
+    - humanize <2,>=1.0.0
+    - janus <1.1,>=0.6
+    - nest-asyncio <2,>=1.5.8
+    - orjson <4,>=3.6.4
+    - protobuf ==3.20.2
+    - rich <13,>=12.6.0
+    - typer <1,>=0.9.0
+    - python-json-logger <3,>=2.0.2
+    - pyyaml <7.0,>=6.0
+    - sortedcontainers <3,>=2.4.0
+    - tabulate <1,>=0.8.9
+    - jproperties <3,>=2.1.1
+    - avro <1.12,>=1.10
+    - bokeh <4,>=3
+    - decorator <5
+    - Deprecated <1.3,>=1.2.10
+    - numpy <2
+    - pandas <3,>=2
+    - parsimonious <1
+    - plotly <6,>=5.18.0
+    - pyspark <=3.4.1,>=3.3.2
+    - requests <3,>=2.31.0
+    - scipy <1.12,>1.2
+    - uvloop <1,>=0.19.0  # [not win]
+
+test:
+  imports:
+    - hail
+    - hailtop.batch
+
+about:
+  home: https://hail.is
+  dev_url: https://github.com/hail-is/hail
+  license: MIT
+  license_file: LICENSE
+  summary: |
+    Hail is Python-based data analysis tool for working with genomic data.
+
+extra:
+  skip-lints:
+    - uses_vcs_url
+  recipe-maintainers:
+    - raivivek

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,8 +80,9 @@ requirements:
     - python
     # prerequisites
     - openjdk 11.*
-    # blas (lapack is brought in along)
-    - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
+    # blas, lapack:
+    #   openblas-devel has a run export for libopenblas, 
+    #   and lapack is brought in along.
     # deps
     - aiodns >=2.0.0,<3
     - aiohttp >=3.9,<4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - openjdk 11.*
     - lz4
     # blas (lapack is brought in along)
+    - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
     # libsimdpp and catch2 unvendored dependencies
     - libsimdpp
     - catch2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
     - patches/0001-remove-vendored-libsimdpp.patch
     - patches/0002-remove-vendored-catch2.patch
     - patches/0003-patch-requirements.patch
+    - patches/0004-pluggy-old-style-wrappers.patch
 
 build:
   number: 0
@@ -118,10 +119,15 @@ test:
   imports:
     - hail
     - hailtop.batch
+  source_files:
+    - hail/python/test
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - cd hail/python
+    - pytest -v test --ignore=test/hailtop/ --ignore=test/hail/matrixtable/test_file_formats.py --ignore=test/hail/experimental/test_experimental.py --ignore=test/hail/expr/test_expr.py --ignore=test/hail/matrixtable/test_matrix_table.py --ignore=test/hail/methods/test_family_methods.py --ignore=test/hail/methods/test_impex.py --ignore=test/hail/methods/test_pca.py --ignore=test/hail/methods/test_skat.py --ignore=test/hail/methods/test_statgen.py --ignore=test/hail/methods/relatedness/test_pc_relate.py --ignore=test/hail/table/test_table.py --ignore=test/hail/vds/test_combiner.py --ignore=test/hail/vds/test_vds.py 
 
 about:
   home: https://hail.is

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
   # (e.g. version)
   git_url: https://github.com/hail-is/hail.git
   git_rev: {{ version }}
+  patches:
+    - patches/0001-remove-vendored-libsimdpp.patch
 
 build:
   number: 0
@@ -22,6 +24,8 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - make  # [linux]
+    - patch     # [not win]
+    - m2-patch  # [win]
     # - rsync
     # - setuptools
     # - pytest-runner
@@ -105,6 +109,8 @@ requirements:
     - requests <3,>=2.31.0
     - scipy <1.12,>1.2
     - uvloop <1,>=0.19.0  # [not win]
+    # because pkg_resources is needed
+    - setuptools
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,14 @@ requirements:
     - python
     - pip
     - setuptools
-    # pre requisites
+    # prerequisites
     - pytest-runner
     - pyspark >=3.3.2,<=3.4.1
     - openjdk 11.*
     - lz4
+    # blas (lapack is brought in along)
+    - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
+    - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
     # libsimdpp and catch2 unvendored dependencies
     - libsimdpp
     - catch2
@@ -75,7 +78,12 @@ requirements:
     - jproperties >=2.1.1,<3
   run:
     - python
+    # prerequisites
     - openjdk 11.*
+    # blas (lapack is brought in along)
+    - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
+    - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
+    # deps
     - aiodns >=2.0.0,<3
     - aiohttp >=3.9,<4
     - azure-identity >=1.6.0,<2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,9 @@ requirements:
     - {{ compiler('cxx') }}
     - make  # [linux]
     # - rsync
+    # - setuptools
+    # - pytest-runner
+    - git
   host:
     - python
     - pip
@@ -60,7 +63,6 @@ requirements:
     - tabulate >=0.8.9,<1
     - uvloop >=0.19.0,<1  # [not win]
     - jproperties >=2.1.1,<3
-    - pkg_resources
   run:
     - python
     - openjdk 11.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/hail-is/hail.git
-  git_rev: {{ version }}
+  url: https://github.com/hail-is/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: def7eb3e17d15bbb3dfba00dfc8a966771b839b04b639386ee61c8927d0c7ae8
 
 build:
   number: 0
@@ -89,9 +89,9 @@ about:
     Hail is exposed as a Python library, using primitives for distributed queries and
     linear algebra implemented in Scala, Spark, and increasingly C++.
   dev_url: https://github.com/hail-is/hail
-  doc_url: https://hail.is/docs/0.2/
+  doc_url: https://hail.is/docs/0.2/index.html
 extra:
   skip-lints:
-    - uses_vcs_url
+    - host_section_needs_exact_pinnings
   recipe-maintainers:
     - raivivek

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,8 @@ source:
 build:
   number: 0
   # avro and others a not available for win
-  skip: true  # [py<39 or win or py>311]
+  # openjdk and pyspark not available for s390x
+  skip: true  # [py<39 or win or py>311 or s390x]
   # entry_points:
   #   - hailctl = hailtop.hailctl.__main__:main
 
@@ -26,9 +27,6 @@ requirements:
     - make  # [linux]
     - patch     # [not win]
     - m2-patch  # [win]
-    # - rsync
-    # - setuptools
-    # - pytest-runner
     - git
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
   patches:
     - patches/0001-remove-vendored-libsimdpp.patch
     - patches/0002-remove-vendored-catch2.patch
+    - patches/0003-patch-requirements.patch
 
 build:
   number: 0
@@ -117,6 +118,10 @@ test:
   imports:
     - hail
     - hailtop.batch
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://hail.is

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,20 @@ source:
   git_rev: {{ version }}
   patches:
     - patches/0001-remove-vendored-libsimdpp.patch
+    - patches/0002-remove-vendored-catch2.patch
 
 build:
   number: 0
   # avro and others a not available for win
   # openjdk and pyspark not available for s390x
   skip: true  # [py<39 or win or py>311 or s390x]
-  # entry_points:
-  #   - hailctl = hailtop.hailctl.__main__:main
+  entry_points:
+    - hailctl = hailtop.hailctl.__main__:main
 
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - make  # [linux]
+    - make      # [linux]
     - patch     # [not win]
     - m2-patch  # [win]
     - git
@@ -36,8 +37,10 @@ requirements:
     - pyspark >=3.3.2,<=3.4.1
     - openjdk 11.*
     - lz4
+    # libsimdpp and catch2 unvendored dependencies
     - libsimdpp
-    # hailctl build needs these here
+    - catch2
+    # hail build needs these here to build hailtop/hailctl
     - aiodns >=2.0.0,<3
     - aiohttp >=3.9,<4
     - azure-identity >=1.6.0,<2
@@ -136,5 +139,6 @@ about:
 extra:
   skip-lints:
     - host_section_needs_exact_pinnings
+    - python_build_tool_in_run
   recipe-maintainers:
     - raivivek

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,12 @@ requirements:
     - janus <1.1,>=0.6
     - nest-asyncio <2,>=1.5.8
     - orjson <4,>=3.6.4
-    - protobuf ==3.20.2
-    - rich <13,>=12.6.0
+    # - protobuf ==3.20.2
+    # we have protobuf 3.20.3
+    - protobuf >=3.20.2,<=3.20.3
+    # - rich <13,>=12.6.0
+    # we have rich 12.5.0
+    - rich <13,>=12.5.0
     - typer <1,>=0.9.0
     - python-json-logger <3,>=2.0.2
     - pyyaml <7.0,>=6.0

--- a/recipe/patches/0001-remove-vendored-libsimdpp.patch
+++ b/recipe/patches/0001-remove-vendored-libsimdpp.patch
@@ -1,0 +1,71 @@
+From 350966f397a684e911241026d20a65da053a5873 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Mon, 4 Mar 2024 14:29:24 -0600
+Subject: [PATCH] remove vendored libsimdpp
+
+---
+ hail/src/main/c/Makefile | 17 +++++------------
+ 1 file changed, 5 insertions(+), 12 deletions(-)
+
+diff --git a/hail/src/main/c/Makefile b/hail/src/main/c/Makefile
+index d750ca09e..645d347bc 100644
+--- a/hail/src/main/c/Makefile
++++ b/hail/src/main/c/Makefile
+@@ -25,8 +25,7 @@ CATCH_HEADER_LOCATION := ../resources/include/catch.hpp
+ 
+ # before libsimdpp and catch.hpp are downloaded, clang -MG -MM will generate
+ # unresolved dependencies
+-.PHONY: simdpp/simd.h catch.hpp
+-simdpp/simd.h: $(LIBSIMDPP)
++.PHONY: catch.hpp
+ catch.hpp: $(CATCH_HEADER_LOCATION)
+ 
+ 
+@@ -70,7 +69,7 @@ ifneq ($(WARNFLAGS),)
+ endif
+ 
+ # Append to any inherited flags which survived filtering
+-CXXFLAGS += $(HAIL_OPT_FLAGS) $(CXXSTD) -I$(LIBSIMDPP) -Wall -Wextra
++CXXFLAGS += $(HAIL_OPT_FLAGS) $(CXXSTD) -I$(PREFIX)/include/$(LIBSIMDPP) -Wall -Wextra
+ CXXFLAGS += -fPIC -ggdb -fno-strict-aliasing
+ CXXFLAGS += -I../resources/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(JAVA_MD)
+ LIBFLAGS += -fvisibility=default
+@@ -215,11 +214,11 @@ endif
+ 	echo "CXX is $(CXX)"
+ 	-$(CXX) --version
+ 
+-$(BUILD_X86_64)/functional-tests: ibs.cpp test.cpp $(LIBSIMDPP)
++$(BUILD_X86_64)/functional-tests: ibs.cpp test.cpp
+ 	@mkdir -p $(@D)
+ 	$(CXX) $(CXXFLAGS) -DNUMBER_OF_GENOTYPES_PER_ROW=256 -o $(BUILD_X86_64)/functional-tests ibs.cpp test.cpp
+ 
+-$(BUILD_ARM64)/functional-tests: ibs.cpp test.cpp $(LIBSIMDPP)
++$(BUILD_ARM64)/functional-tests: ibs.cpp test.cpp
+ 	@mkdir -p $(@D)
+ 	$(CXX) $(CXXFLAGS) -DNUMBER_OF_GENOTYPES_PER_ROW=256 -o $(BUILD_ARM64)/functional-tests ibs.cpp test.cpp
+ 
+@@ -259,7 +258,7 @@ benchmark: $(BUILD_NATIVE)/unit-tests
+ 			esac
+ 
+ clean:
+-	-rm -rf $(BUILD) $(LIBSIMDPP) lib
++	-rm -rf $(BUILD) lib
+ 
+ # We take all headers files visible to dynamic-generated code, together with
+ # the output of "$(CXX) --version", to give a checksum $(ALL_HEADER_CKSUM)
+@@ -283,12 +282,6 @@ $(CATCH_HEADER_LOCATION):
+ 	@mkdir -p $(@D)
+ 	curl -sSL 'https://github.com/catchorg/Catch2/releases/download/v2.6.0/catch.hpp' > $@
+ 
+-$(LIBSIMDPP).tar.gz:
+-	curl -sSL https://storage.googleapis.com/hail-common/$@ > $@
+-
+-$(LIBSIMDPP): $(LIBSIMDPP).tar.gz
+-	tar -xzf $<
+-
+ ifeq ($(UNAME_S)-$(UNAME_M),Darwin-arm64)
+ $(LIBBOOT_X86_64): $(BUILD_X86_64)/NativeBoot.o
+ 	@mkdir -p $(dir $@)
+-- 
+2.39.1
+

--- a/recipe/patches/0002-remove-vendored-catch2.patch
+++ b/recipe/patches/0002-remove-vendored-catch2.patch
@@ -1,0 +1,36 @@
+From 2d511977a026e02845ea541d073c08be1d7ebb64 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Mon, 4 Mar 2024 19:31:50 -0600
+Subject: [PATCH] remove vendored catch2
+
+---
+ hail/src/main/c/Makefile | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/hail/src/main/c/Makefile b/hail/src/main/c/Makefile
+index 645d347bc..bcf67739f 100644
+--- a/hail/src/main/c/Makefile
++++ b/hail/src/main/c/Makefile
+@@ -21,7 +21,7 @@ endif
+ # Change this setting to update the version of libsimdpp
+ LIBSIMDPP := libsimdpp-2.1
+ 
+-CATCH_HEADER_LOCATION := ../resources/include/catch.hpp
++CATCH_HEADER_LOCATION := $(PREFIX)/include/catch2/catch.hpp
+ 
+ # before libsimdpp and catch.hpp are downloaded, clang -MG -MM will generate
+ # unresolved dependencies
+@@ -278,10 +278,6 @@ $(BUILD_ARM64)/NativeModule.o: NativeModule.cpp
+ 	@mkdir -p $(@D)
+ 	$(CXX) $(CXXFLAGS_ARM64) -DALL_HEADER_CKSUM=$(ALL_HEADER_CKSUM)UL -c NativeModule.cpp -o $@
+ 
+-$(CATCH_HEADER_LOCATION):
+-	@mkdir -p $(@D)
+-	curl -sSL 'https://github.com/catchorg/Catch2/releases/download/v2.6.0/catch.hpp' > $@
+-
+ ifeq ($(UNAME_S)-$(UNAME_M),Darwin-arm64)
+ $(LIBBOOT_X86_64): $(BUILD_X86_64)/NativeBoot.o
+ 	@mkdir -p $(dir $@)
+-- 
+2.39.1
+

--- a/recipe/patches/0003-patch-requirements.patch
+++ b/recipe/patches/0003-patch-requirements.patch
@@ -1,0 +1,42 @@
+From 2b10a6a6f90fd0d97456edc6bfe540ce8b3705a2 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Mon, 11 Mar 2024 13:14:13 -0600
+Subject: [PATCH] patch requirements
+
+---
+ hail/python/hailtop/requirements.txt | 4 ++--
+ hail/python/requirements.txt         | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/hail/python/hailtop/requirements.txt b/hail/python/hailtop/requirements.txt
+index a7d7f2f18..d3fe9eb63 100644
+--- a/hail/python/hailtop/requirements.txt
++++ b/hail/python/hailtop/requirements.txt
+@@ -13,8 +13,8 @@ humanize>=1.0.0,<2
+ janus>=0.6,<1.1
+ nest_asyncio>=1.5.8,<2
+ orjson>=3.6.4,<4
+-protobuf==3.20.2
+-rich>=12.6.0,<13
++protobuf==3.20.3
++rich>=12.5.0,<13
+ typer>=0.9.0,<1
+ python-json-logger>=2.0.2,<3
+ pyyaml>=6.0,<7.0
+diff --git a/hail/python/requirements.txt b/hail/python/requirements.txt
+index 4c53c351b..d6a732731 100644
+--- a/hail/python/requirements.txt
++++ b/hail/python/requirements.txt
+@@ -10,7 +10,7 @@ numpy<2
+ pandas>=2,<3
+ parsimonious<1
+ plotly>=5.18.0,<6
+-protobuf==3.20.2
+-pyspark>=3.3.2,<3.4
++protobuf==3.20.3
++pyspark>=3.3.2,<=3.4.1
+ requests>=2.31.0,<3
+ scipy>1.2,<1.12
+-- 
+2.39.1
+

--- a/recipe/patches/0004-pluggy-old-style-wrappers.patch
+++ b/recipe/patches/0004-pluggy-old-style-wrappers.patch
@@ -1,0 +1,44 @@
+From 95952cebf8730a0c8f6adfc69bf4466fcafcf0ee Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Tue, 12 Mar 2024 07:41:39 -0600
+Subject: [PATCH] pluggy old-style wrappers
+
+Our version of pluggy is old (1.0.0) and does not support the new
+style of wrappers (introduced in >=1.1.0, where 1.1.0 is yanked).
+
+This patch changes this wrapper to an old-style wrapper.
+
+See: https://pluggy.readthedocs.io/en/stable/index.html#old-style-wrappers
+
+---
+ hail/python/test/hail/conftest.py | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/hail/python/test/hail/conftest.py b/hail/python/test/hail/conftest.py
+index 3423e6919..b84bb8fea 100644
+--- a/hail/python/test/hail/conftest.py
++++ b/hail/python/test/hail/conftest.py
+@@ -59,12 +59,17 @@ def reset_randomness(init_hail):
+ test_results_key = StashKey[Dict[str, CollectReport]]()
+ 
+ 
+-@pytest.hookimpl(wrapper=True, tryfirst=True)
++@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+ def pytest_runtest_makereport(item, call):
+     # from: https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
+     report = yield
+-    item.stash.setdefault(test_results_key, {})[report.when] = report
+-    return report
++    try:
++        rep = report.get_result()
++    except BaseException as e:
++        report.force_exception(e)
++        return
++    item.stash.setdefault(test_results_key, {})[rep.when] = rep
++    report.force_result(rep)
+ 
+ 
+ @pytest.fixture(autouse=True)
+-- 
+2.39.1
+

--- a/recipe/patches/0005-patch-spark-3.3.2-to-3.4.1.patch
+++ b/recipe/patches/0005-patch-spark-3.3.2-to-3.4.1.patch
@@ -1,0 +1,106 @@
+From ad278eab6414ebfd865dd3abf72a5a0ef533cec3 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Tue, 12 Mar 2024 11:38:20 -0600
+Subject: [PATCH] patch spark 3.3.2 to 3.4.1
+
+Pin the version of spark to 3.4.1
+
+This change requires an update of breezeVersion to 2.1.0 anaconda
+update some Scala code.
+
+See: https://github.com/hail-is/hail/issues/13971
+
+In particular: https://github.com/hail-is/hail/issues/13971#issuecomment-1792870445
+
+---
+ batch/Dockerfile.worker                       | 2 +-
+ batch/jvm-entryway/build.gradle               | 2 +-
+ hail/build.gradle                             | 7 ++-----
+ hail/src/main/scala/is/hail/HailContext.scala | 4 ++--
+ hail/version.mk                               | 2 +-
+ 5 files changed, 7 insertions(+), 10 deletions(-)
+
+diff --git a/batch/Dockerfile.worker b/batch/Dockerfile.worker
+index 5fa4599b0..e8a4f9d39 100644
+--- a/batch/Dockerfile.worker
++++ b/batch/Dockerfile.worker
+@@ -51,7 +51,7 @@ RUN hail-pip-install \
+     -r hailtop-requirements.txt \
+     -r gear-requirements.txt \
+     -r batch-requirements.txt \
+-    pyspark==3.3.2
++    pyspark==3.4.1
+ 
+ ENV SPARK_HOME /usr/local/lib/python3.9/dist-packages/pyspark
+ ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
+diff --git a/batch/jvm-entryway/build.gradle b/batch/jvm-entryway/build.gradle
+index 3df60b959..1087b92a8 100644
+--- a/batch/jvm-entryway/build.gradle
++++ b/batch/jvm-entryway/build.gradle
+@@ -17,7 +17,7 @@ repositories {
+ }
+ 
+ project.ext {
+-    sparkVersion = System.getProperty("spark.version", "3.3.2")
++    sparkVersion = System.getProperty("spark.version", "3.4.1")
+     scalaVersion = System.getProperty("scala.version", "2.12.18")
+ }
+ 
+diff --git a/hail/build.gradle b/hail/build.gradle
+index 64041f9b4..6d2b82c8d 100644
+--- a/hail/build.gradle
++++ b/hail/build.gradle
+@@ -42,13 +42,10 @@ tasks.withType(JavaCompile) {
+ }
+ 
+ project.ext {
+-    breezeVersion = "1.1"
++    breezeVersion = "2.1.0"
+ 
+-    sparkVersion = System.getProperty("spark.version", "3.3.2")
++    sparkVersion = System.getProperty("spark.version", "3.4.1")
+ 
+-    if (sparkVersion != "3.3.2") {
+-        project.logger.lifecycle("WARNING: Hail primarily tested with Spark 3.3.2, use other versions at your own risk.")
+-    }
+     scalaVersion = System.getProperty("scala.version", "2.12.18")
+     scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]
+     assert(scalaMajorVersion == "2.12")
+diff --git a/hail/src/main/scala/is/hail/HailContext.scala b/hail/src/main/scala/is/hail/HailContext.scala
+index d1c39238d..2dc459fd4 100644
+--- a/hail/src/main/scala/is/hail/HailContext.scala
++++ b/hail/src/main/scala/is/hail/HailContext.scala
+@@ -118,7 +118,7 @@ object HailContext {
+ 
+     {
+       import breeze.linalg._
+-      import breeze.linalg.operators.{BinaryRegistry, OpMulMatrix}
++      import breeze.linalg.operators.{BinaryRegistry, HasOps, OpMulMatrix}
+ 
+       implicitly[BinaryRegistry[
+         DenseMatrix[Double],
+@@ -126,7 +126,7 @@ object HailContext {
+         OpMulMatrix.type,
+         DenseVector[Double],
+       ]].register(
+-        DenseMatrix.implOpMulMatrix_DMD_DVD_eq_DVD
++        HasOps.impl_OpMulMatrix_DMD_DVD_eq_DVD
+       )
+     }
+ 
+diff --git a/hail/version.mk b/hail/version.mk
+index e166a09ed..e0d823025 100644
+--- a/hail/version.mk
++++ b/hail/version.mk
+@@ -14,7 +14,7 @@ $(error "git rev-parse --abbrev-ref HEAD" failed to produce output)
+ endif
+ 
+ SCALA_VERSION ?= 2.12.18
+-SPARK_VERSION ?= 3.3.2
++SPARK_VERSION ?= 3.4.1
+ HAIL_MAJOR_MINOR_VERSION := 0.2
+ HAIL_PATCH_VERSION := 127
+ HAIL_PIP_VERSION := $(HAIL_MAJOR_MINOR_VERSION).$(HAIL_PATCH_VERSION)
+-- 
+2.39.1
+


### PR DESCRIPTION
hail 0.2.127 ❄️

**Destination channel:** Snowflake

### Links

- [PKG-3771]
- dev_url (pypi): https://github.com/hail-is/hail/tree/0.2.127
- pypi: https://pypi.org/project/hail
- Recipe (from bioconda): https://github.com/bioconda/bioconda-recipes/tree/master/recipes/hail
- inspector: https://inspector.pypi.io/project/hail/0.2.127

*NB* hail 0.2.128 is out https://pypi.org/project/hail/0.2.128

### Explanation of changes:

- draft recipe (from bioconda)
- patches:
    - remove vendored libsimdpp
    - remove vendored catch2
    - patch requirements (we use what we have available for `pyspark`, `rich`, `protobuf`)
    - patch pluggy old-style-wrappers for tests
    - patch `spark` `3.3.2` to `3.4.1`, with additional fix for Mac Silicon (M1, M2)
- skip/ignore tests that require a backend or datafiles
- tests density: 613 passed, 7 skipped, 81 deselected, 1 xfailed in 237.55s (0:03:57)
- in `host` there are a bunch of deps, introduced because `hailtop` is being built before everything else, see its [hail/python/setup-hailtop.py](https://github.com/hail-is/hail/blob/0.2.127/hail/python/setup-hailtop.py), and its [dependencies](https://github.com/hail-is/hail/blob/0.2.127/hail/python/hailtop/requirements.txt).

### Notes for reviewers:

- `catch2` has been unvendored, but it does not seem to be used in the `make` process? I might have unvendored too much.
- See comments in the patch files for more info about why, unless obvious.
- To build it locally, I suggest using a container because I had some overlapping with stuff on my system that was making things different from Prefect:
    ```
    > cd ~/aggregate
    
    > docker run -ti --platform linux/arm64 --rm -v `pwd`:/aggregate public.ecr.aws/y0o4y9o3/anaconda-pkg-build:latest /bin/bash
    
    bash-4.2# cd aggregate
    
    bash-4.2# conda build --error-overlinking --error-overdepending --suppress-variables hail-feedstock -c sfe1ed40
    ```

[PKG-3771]: https://anaconda.atlassian.net/browse/PKG-3771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ